### PR TITLE
Fix resolver list query names

### DIFF
--- a/apps/audit/schema.gql
+++ b/apps/audit/schema.gql
@@ -3,11 +3,13 @@
 # ------------------------------------------------------
 
 type Audit {
+  id: Int!
   """Example field (placeholder)"""
   exampleField: Int!
 }
 
 type Query {
+  audits: [Audit!]!
   audit(id: Int!): Audit!
 }
 

--- a/apps/audit/src/audit.resolver.spec.ts
+++ b/apps/audit/src/audit.resolver.spec.ts
@@ -1,13 +1,27 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { AuditResolver } from './audit.resolver';
 import { AuditService } from './audit.service';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Audit } from './entities/audit.entity';
+import { RedisService } from '../../../libs/redis/src/redis.service';
 
 describe('AuditResolver', () => {
   let resolver: AuditResolver;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [AuditResolver, AuditService],
+      providers: [
+        AuditResolver,
+        AuditService,
+        {
+          provide: getRepositoryToken(Audit),
+          useValue: { find: jest.fn() },
+        },
+        {
+          provide: RedisService,
+          useValue: { get: jest.fn(), set: jest.fn(), del: jest.fn() },
+        },
+      ],
     }).compile();
 
     resolver = module.get<AuditResolver>(AuditResolver);

--- a/apps/audit/src/audit.resolver.ts
+++ b/apps/audit/src/audit.resolver.ts
@@ -13,7 +13,7 @@ export class AuditResolver {
     return this.auditService.create(createAuditInput);
   }
 
-  @Query(() => [Audit], { name: 'audit' })
+  @Query(() => [Audit], { name: 'audits' })
   findAll() {
     return this.auditService.findAll();
   }

--- a/apps/audit/src/audit.service.spec.ts
+++ b/apps/audit/src/audit.service.spec.ts
@@ -1,12 +1,25 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { AuditService } from './audit.service';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Audit } from './entities/audit.entity';
+import { RedisService } from '../../../libs/redis/src/redis.service';
 
 describe('AuditService', () => {
   let service: AuditService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [AuditService],
+      providers: [
+        AuditService,
+        {
+          provide: getRepositoryToken(Audit),
+          useValue: { find: jest.fn() },
+        },
+        {
+          provide: RedisService,
+          useValue: { get: jest.fn(), set: jest.fn() },
+        },
+      ],
     }).compile();
 
     service = module.get<AuditService>(AuditService);

--- a/apps/audit/src/audit.service.ts
+++ b/apps/audit/src/audit.service.ts
@@ -1,15 +1,35 @@
 import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
 import { CreateAuditInput } from './dto/create-audit.input';
 import { UpdateAuditInput } from './dto/update-audit.input';
+import { Audit } from './entities/audit.entity';
+import { RedisService } from '../../../libs/redis/src/redis.service';
 
 @Injectable()
 export class AuditService {
-  create(createAuditInput: CreateAuditInput) {
-    return 'This action adds a new audit';
+  constructor(
+    @InjectRepository(Audit)
+    private readonly auditRepository: Repository<Audit>,
+    private readonly redisService: RedisService,
+  ) {}
+
+  async create(createAuditInput: CreateAuditInput): Promise<Audit> {
+    const audit = this.auditRepository.create(createAuditInput as unknown as Audit);
+    const saved: Audit = await this.auditRepository.save(audit);
+    await this.redisService.del('all_audits');
+    return saved;
   }
 
-  findAll() {
-    return `This action returns all audit`;
+  async findAll(): Promise<Audit[]> {
+    const cacheKey = 'all_audits';
+    const cached = await this.redisService.get<Audit[]>(cacheKey);
+    if (cached) {
+      return cached;
+    }
+    const audits = await this.auditRepository.find();
+    await this.redisService.set(cacheKey, audits, 60);
+    return audits;
   }
 
   findOne(id: number) {

--- a/apps/audit/src/entities/audit.entity.ts
+++ b/apps/audit/src/entities/audit.entity.ts
@@ -1,7 +1,14 @@
 import { ObjectType, Field, Int } from '@nestjs/graphql';
+import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
 
 @ObjectType()
+@Entity()
 export class Audit {
+  @Field(() => Int)
+  @PrimaryGeneratedColumn()
+  id: number;
+
   @Field(() => Int, { description: 'Example field (placeholder)' })
+  @Column()
   exampleField: number;
 }

--- a/apps/des-form/schema.gql
+++ b/apps/des-form/schema.gql
@@ -8,6 +8,7 @@ type DesForm {
 }
 
 type Query {
+  desForms: [DesForm!]!
   desForm(id: Int!): DesForm!
 }
 

--- a/apps/des-form/src/des-form.resolver.ts
+++ b/apps/des-form/src/des-form.resolver.ts
@@ -13,7 +13,7 @@ export class DesFormResolver {
     return this.desFormService.create(createDesFormInput);
   }
 
-  @Query(() => [DesForm], { name: 'desForm' })
+  @Query(() => [DesForm], { name: 'desForms' })
   findAll() {
     return this.desFormService.findAll();
   }

--- a/apps/notification/schema.gql
+++ b/apps/notification/schema.gql
@@ -8,6 +8,7 @@ type Notification {
 }
 
 type Query {
+  notifications: [Notification!]!
   notification(id: Int!): Notification!
 }
 

--- a/apps/notification/src/notification.resolver.ts
+++ b/apps/notification/src/notification.resolver.ts
@@ -13,7 +13,7 @@ export class NotificationResolver {
     return this.notificationService.create(createNotificationInput);
   }
 
-  @Query(() => [Notification], { name: 'notification' })
+  @Query(() => [Notification], { name: 'notifications' })
   findAll() {
     return this.notificationService.findAll();
   }

--- a/apps/organization/schema.gql
+++ b/apps/organization/schema.gql
@@ -8,6 +8,7 @@ type Organization {
 }
 
 type Query {
+  organizations: [Organization!]!
   organization(id: Int!): Organization!
 }
 

--- a/apps/organization/src/organization.resolver.ts
+++ b/apps/organization/src/organization.resolver.ts
@@ -13,7 +13,7 @@ export class OrganizationResolver {
     return this.organizationService.create(createOrganizationInput);
   }
 
-  @Query(() => [Organization], { name: 'organization' })
+  @Query(() => [Organization], { name: 'organizations' })
   findAll() {
     return this.organizationService.findAll();
   }

--- a/apps/singhealth/schema.gql
+++ b/apps/singhealth/schema.gql
@@ -8,6 +8,7 @@ type Singhealth {
 }
 
 type Query {
+  singhealths: [Singhealth!]!
   singhealth(id: Int!): Singhealth!
 }
 

--- a/apps/singhealth/src/singhealth.resolver.ts
+++ b/apps/singhealth/src/singhealth.resolver.ts
@@ -13,7 +13,7 @@ export class SinghealthResolver {
     return this.singhealthService.create(createSinghealthInput);
   }
 
-  @Query(() => [Singhealth], { name: 'singhealth' })
+  @Query(() => [Singhealth], { name: 'singhealths' })
   findAll() {
     return this.singhealthService.findAll();
   }

--- a/libs/database/src/database.module.ts
+++ b/libs/database/src/database.module.ts
@@ -11,6 +11,7 @@ import { Module, Global } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { Project } from '../../../apps/project/src/entities/project.entity';
+import { Audit } from '../../../apps/audit/src/entities/audit.entity';
 
 @Global()
 @Module({
@@ -23,7 +24,7 @@ import { Project } from '../../../apps/project/src/entities/project.entity';
         url: configService.get<string>('MONGODB_URI'),
         database: configService.get<string>('MONGODB_DATABASE'),
         // entities: [__dirname + '/../**/*.entity{.ts,js}'],
-        entities: [Project], 
+        entities: [Project, Audit],
         synchronize: true, // disable in production
         useUnifiedTopology: true,
         useNewUrlParser: true,


### PR DESCRIPTION
## Summary
- rename resolver list queries to plural form
- implement AuditService.findAll with caching and TypeORM
- update Audit entity and database module
- adjust tests for Audit resolver/service

## Testing
- `npm test` *(fails: RedisService, RmqService, DatabaseService tests due to unresolved providers)*

------
https://chatgpt.com/codex/tasks/task_b_68555b4ec2ec832e8272fbe429bc07f6